### PR TITLE
Ignore the fact that `match` isn't documented.

### DIFF
--- a/deinprogramm/deinprogramm/tests/test-docs-complete.rkt
+++ b/deinprogramm/deinprogramm/tests/test-docs-complete.rkt
@@ -4,7 +4,7 @@
 (check-docs (quote deinprogramm/world))
 (check-docs (quote deinprogramm/image))
 
-(check-docs (quote deinprogramm/DMdA-beginner) #:skip #rx"(^#%)|(^\\.\\.)|(^contract$)|(^define-contract$)")
-(check-docs (quote deinprogramm/DMdA-vanilla) #:skip #rx"(^#%)|(^\\.\\.)|(^contract$)|(^define-contract$)")
-(check-docs (quote deinprogramm/DMdA-advanced) #:skip #rx"(^#%)|(^\\.\\.)|(^contract$)|(^define-contract$)")
-(check-docs (quote deinprogramm/DMdA-assignments) #:skip #rx"(^#%)|(^\\.\\.)|(^contract$)|(^define-contract$)")
+(check-docs (quote deinprogramm/DMdA-beginner) #:skip #rx"(^#%)|(^\\.\\.)|(^contract$)|(^define-contract$)|(^match$)")
+(check-docs (quote deinprogramm/DMdA-vanilla) #:skip #rx"(^#%)|(^\\.\\.)|(^contract$)|(^define-contract$)|(^match$)")
+(check-docs (quote deinprogramm/DMdA-advanced) #:skip #rx"(^#%)|(^\\.\\.)|(^contract$)|(^define-contract$)|(^match$)")
+(check-docs (quote deinprogramm/DMdA-assignments) #:skip #rx"(^#%)|(^\\.\\.)|(^contract$)|(^define-contract$)|(^match$)")


### PR DESCRIPTION
Fixes #2. Alternative would be to document it.